### PR TITLE
Sync frontend models with backend

### DIFF
--- a/src/backend/data/highlights.json
+++ b/src/backend/data/highlights.json
@@ -6,6 +6,7 @@
     "title": "Highlight trận khai mạc",
     "videoUrl": "https://www.youtube.com/watch?v=vid1",
     "description": "Pha kết liễu mãn nhãn",
+    "status": "public",
     "createdAt": "2025-03-01T20:00:00Z"
   },
   {
@@ -15,6 +16,7 @@
     "title": "Highlight bán kết Summer",
     "videoUrl": "https://www.youtube.com/watch?v=vid2",
     "description": "Pha solo cực căng",
+    "status": "public",
     "createdAt": "2025-06-20T18:00:00Z"
   }
 ]

--- a/src/backend/data/news.json
+++ b/src/backend/data/news.json
@@ -6,6 +6,7 @@
     "content": "Hãy sẵn sàng cho giải mùa xuân...",
     "images": ["http://example.com/news/spring1.jpg"],
     "authorId": "640002",
+    "status": "public",
     "publishedAt": "2025-02-25"
   },
   {
@@ -15,6 +16,7 @@
     "content": "Nhiều đội mạnh sẽ tranh tài...",
     "images": ["http://example.com/news/summer1.jpg"],
     "authorId": "640002",
+    "status": "public",
     "publishedAt": "2025-06-10"
   }
 ]

--- a/src/backend/data/tournaments.json
+++ b/src/backend/data/tournaments.json
@@ -5,7 +5,9 @@
     "format": "round",
     "description": "Giải đấu mùa hè",
     "avatarUrl": "",
-    "sponsors": [],
+    "gameName": "",
+    "numberOfPlayers": 0,
+    "maxPlayers": 0,
     "startDate": "2025-06-01T00:00:00.000Z",
     "endDate":   "2025-06-15T00:00:00.000Z",
     "status": "upcoming"
@@ -16,7 +18,9 @@
     "format": "single",
     "description": "Giải đấu mùa đông",
     "avatarUrl": "",
-    "sponsors": [],
+    "gameName": "",
+    "numberOfPlayers": 0,
+    "maxPlayers": 0,
     "startDate": "2025-12-01T00:00:00.000Z",
     "endDate":   "2025-12-10T00:00:00.000Z",
     "status": "upcoming"
@@ -27,10 +31,9 @@
     "format": "single",
     "description": "Giải đấu seed mặc định",
     "avatarUrl": "",
-    "sponsors": [
-      { "name": "Sponsor A", "logoUrl": "" },
-      { "name": "Sponsor B", "logoUrl": "" }
-    ],
+    "gameName": "",
+    "numberOfPlayers": 0,
+    "maxPlayers": 0,
     "startDate": "2025-08-01T00:00:00.000Z",
     "endDate":   "2025-08-10T00:00:00.000Z",
     "status": "upcoming"

--- a/src/backend/models/Highlight.js
+++ b/src/backend/models/Highlight.js
@@ -26,6 +26,11 @@ const highlightSchema = new mongoose.Schema({
     type: String,
     trim: true
   },
+  status: {
+    type: String,
+    enum: ['private', 'public'],
+    default: 'public'
+  },
   createdAt: {
     type: Date,
     default: Date.now

--- a/src/backend/models/News.js
+++ b/src/backend/models/News.js
@@ -27,6 +27,11 @@ const newsSchema = new mongoose.Schema({
     ref: 'User',
     required: true
   },
+  status: {
+    type: String,
+    enum: ['private', 'public'],
+    default: 'public'
+  },
   publishedAt: {
     type: Date
   }

--- a/src/backend/models/Tournament.js
+++ b/src/backend/models/Tournament.js
@@ -9,7 +9,9 @@ const tournamentSchema = new mongoose.Schema({
   organizerId: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },  // removed required to allow seeding
   teams:       [{ type: mongoose.Schema.Types.ObjectId, ref: 'Competitor', default: [] }],
   avatarUrl:   { type: String },
-  sponsors:    [{ name: String, logoUrl: String }],
+  gameName:    { type: String },
+  numberOfPlayers: { type: Number },
+  maxPlayers:  { type: Number },
   startDate:   { type: Date },
   endDate:     { type: Date },
   status:      { type: String }, // upcoming│ongoing│completed

--- a/src/backend/utils/seed/tournaments.json
+++ b/src/backend/utils/seed/tournaments.json
@@ -5,7 +5,9 @@
     "format": "round",
     "description": "Giải đấu mùa hè",
     "avatarUrl": "",
-    "sponsors": [],
+    "gameName": "",
+    "numberOfPlayers": 0,
+    "maxPlayers": 0,
     "startDate": "2025-06-01T00:00:00.000Z",
     "endDate":   "2025-06-15T00:00:00.000Z",
     "status": "upcoming"
@@ -16,7 +18,9 @@
     "format": "single",
     "description": "Giải đấu mùa đông",
     "avatarUrl": "",
-    "sponsors": [],
+    "gameName": "",
+    "numberOfPlayers": 0,
+    "maxPlayers": 0,
     "startDate": "2025-12-01T00:00:00.000Z",
     "endDate":   "2025-12-10T00:00:00.000Z",
     "status": "upcoming"

--- a/src/frontend/js/controllers/OrganizerController.js
+++ b/src/frontend/js/controllers/OrganizerController.js
@@ -1,5 +1,4 @@
 import Organizer from '../models/Organizer.js';
-import Tournament from '../models/Tournament.js';
 import { renderCreateTournament } from '../views/organizerView.js';
 import { apiCall } from '../api.js';
 
@@ -11,7 +10,11 @@ class OrganizerController {
     async createTournament() {
         const name = document.getElementById('tournamentName').value;
         const format = document.getElementById('tournamentFormat').value;
-        this.currentOrganizer = new Organizer(Date.now().toString(), "Org Name");
+        this.currentOrganizer = new Organizer({
+            _id: Date.now().toString(),
+            fullName: 'Org Name',
+            role: 'organizer'
+        });
         const tournament = this.currentOrganizer.createTournament(name, format);
         await apiCall('http://localhost:3000/api/tournaments', tournament, 'POST');
         renderCreateTournament();

--- a/src/frontend/js/controllers/UserController.js
+++ b/src/frontend/js/controllers/UserController.js
@@ -14,7 +14,12 @@ class UserController {
 
     async login(email) {
         const data = await apiCall('http://localhost:3000/api/login', { email }, 'POST');
-        this.currentUser = new User(data.id, data.name, email);
+        this.currentUser = new User({
+            _id: data.id,
+            email,
+            fullName: data.name,
+            role: data.role
+        });
         // Redirect to index.html after login
         window.location.href = 'index.html';
         renderTournamentDetails(await apiCall('http://localhost:3000/api/tournaments/1'));

--- a/src/frontend/js/models/Organizer.js
+++ b/src/frontend/js/models/Organizer.js
@@ -1,7 +1,17 @@
-class Organizer {
-    constructor(id, name) {
-        this.id = id;
-        this.name = name;
+import User from './User.js';
+import Tournament from './Tournament.js';
+
+class Organizer extends User {
+    constructor(data) {
+        super(data);
+    }
+
+    createTournament(name, format) {
+        return new Tournament({
+            name,
+            format,
+            organizerId: this._id
+        });
     }
 }
 

--- a/src/frontend/js/models/Team.js
+++ b/src/frontend/js/models/Team.js
@@ -1,9 +1,14 @@
 class Team {
-    constructor(id, name, logo, members) {
-        this.id = id;
+    constructor({
+        _id,
+        name,
+        logoUrl = '',
+        tournamentId = null
+    } = {}) {
+        this._id = _id;
         this.name = name;
-        this.logo = logo;
-        this.members = members || [];
+        this.logoUrl = logoUrl;
+        this.tournamentId = tournamentId;
     }
 }
 

--- a/src/frontend/js/models/Tournament.js
+++ b/src/frontend/js/models/Tournament.js
@@ -1,11 +1,32 @@
 class Tournament {
-    constructor(id, name, format) {
-        this.id = id;
+    constructor({
+        _id,
+        name,
+        format,
+        description = '',
+        organizerId = null,
+        teams = [],
+        avatarUrl = '',
+        gameName = '',
+        numberOfPlayers = 0,
+        maxPlayers = 0,
+        startDate = null,
+        endDate = null,
+        status = ''
+    } = {}) {
+        this._id = _id;
         this.name = name;
         this.format = format;
-        this.teams = [];
-        this.sponsors = [];
-        this.results = {};
+        this.description = description;
+        this.organizerId = organizerId;
+        this.teams = teams;
+        this.avatarUrl = avatarUrl;
+        this.gameName = gameName;
+        this.numberOfPlayers = numberOfPlayers;
+        this.maxPlayers = maxPlayers;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = status;
     }
 }
 

--- a/src/frontend/js/models/User.js
+++ b/src/frontend/js/models/User.js
@@ -1,8 +1,16 @@
 class User {
-    constructor(id, name, email) {
-        this.id = id;
-        this.name = name;
+    constructor({
+        _id,
+        email,
+        fullName = '',
+        avatarUrl = '',
+        role = 'user'
+    } = {}) {
+        this._id = _id;
         this.email = email;
+        this.fullName = fullName;
+        this.avatarUrl = avatarUrl;
+        this.role = role;
         this.favorites = [];
     }
 


### PR DESCRIPTION
## Summary
- align frontend models (Tournament, Team, User, Organizer) with backend schemas
- update Organizer and User controllers to use updated models
- add game info to tournaments and add status fields for news/highlights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ba6e32e7483258ce1d6bbbb28080c